### PR TITLE
fix status checks for multiple modules

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1709336216,
+        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1711523803,
+        "narHash": "sha256-UKcYiHWHQynzj6CN/vTcix4yd1eCu1uFdsuarupdCQQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2726f127c15a4cc9810843b96cad73c7eb39e443",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,62 @@
+{
+  description = "Easy and Repeatable Kubernetes Development";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+
+      perSystem = { pkgs, inputs', ... }: {
+
+        packages.default = let
+          buildDate = with inputs; "${self.lastModifiedDate or self.lastModified or "unknown"}";
+          version  = with inputs; "${self.shortRev or self.dirtyShortRev or buildDate}";
+        in pkgs.buildGoModule {
+          pname = "skaffold";
+
+          inherit version;
+
+          src = inputs.self;
+
+          vendorHash = null;
+
+          subPackages = ["cmd/skaffold"];
+
+          ldflags = let
+            p = "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold";
+          in [
+            "-s" "-w"
+            "-X ${p}/version.version=v${version}"
+            "-X ${p}/version.gitCommit=${inputs.self.rev or inputs.self.dirtyRev or "unkown"}"
+            "-X ${p}/version.buildDate=${buildDate}"
+          ];
+
+          nativeBuildInputs = with pkgs; [ installShellFiles makeWrapper ];
+
+          doInstallCheck = true;
+
+          installCheckPhase = ''
+            $out/bin/skaffold version | grep ${version} > /dev/null
+          '';
+
+          postInstall = ''
+            wrapProgram $out/bin/skaffold --set SKAFFOLD_UPDATE_CHECK false
+
+            installShellCompletion --cmd skaffold \
+              --bash <($out/bin/skaffold completion bash) \
+              --zsh <($out/bin/skaffold completion zsh)
+          '';
+
+          meta = {
+            homepage = "https://github.com/GoogleContainerTools/skaffold";
+          };
+        };
+      };
+    };
+}

--- a/pkg/skaffold/deploy/component/kubernetes/component.go
+++ b/pkg/skaffold/deploy/component/kubernetes/component.go
@@ -93,7 +93,7 @@ func newLogger(config k8slogger.Config, cli *kubectl.CLI, podSelector kubernetes
 	return k8slogger.NewLogAggregator(cli, podSelector, namespaces, config)
 }
 
-func newMonitor(cfg k8sstatus.Config, kubeContext string, labeller *label.DefaultLabeller, namespaces *[]string, customResourceSelectors []manifest.GroupKindSelector) k8sstatus.Monitor {
+func newMonitor(cfg k8sstatus.Config, dedupKey string, labeller *label.DefaultLabeller, namespaces *[]string, customResourceSelectors []manifest.GroupKindSelector) k8sstatus.Monitor {
 	if customResourceSelectors == nil {
 		customResourceSelectors = []manifest.GroupKindSelector{}
 	}
@@ -102,15 +102,15 @@ func newMonitor(cfg k8sstatus.Config, kubeContext string, labeller *label.Defaul
 	if k8sMonitor == nil {
 		k8sMonitor = make(map[string]k8sstatus.Monitor)
 	}
-	if k8sMonitor[kubeContext] == nil {
+	if k8sMonitor[dedupKey] == nil {
 		enabled := cfg.StatusCheck()
 		if enabled != nil && !*enabled { // assume disabled only if explicitly set to false
-			k8sMonitor[kubeContext] = &k8sstatus.NoopMonitor{}
+			k8sMonitor[dedupKey] = &k8sstatus.NoopMonitor{}
 		} else {
-			k8sMonitor[kubeContext] = k8sstatus.NewStatusMonitor(cfg, labeller, namespaces, customResourceSelectors)
+			k8sMonitor[dedupKey] = k8sstatus.NewStatusMonitor(cfg, labeller, namespaces, customResourceSelectors)
 		}
 	}
-	return k8sMonitor[kubeContext]
+	return k8sMonitor[dedupKey]
 }
 
 func newSyncer(cli *kubectl.CLI, namespaces *[]string, formatter k8slogger.Formatter) sync.Syncer {

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -105,6 +105,7 @@ func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latest.KubectlD
 	podSelector := kubernetes.NewImageList()
 	kubectl := NewCLI(cfg, d.Flags, defaultNamespace)
 	namespaces, err := deployutil.GetAllPodNamespaces(cfg.GetNamespace(), cfg.GetPipelines())
+
 	if err != nil {
 		olog.Entry(context.TODO()).Warn("unable to parse namespaces - deploy might not work correctly!")
 	}
@@ -134,7 +135,7 @@ func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latest.KubectlD
 		debugger:            component.NewDebugger(cfg.Mode(), podSelector, &namespaces, cfg.GetKubeContext()),
 		imageLoader:         component.NewImageLoader(cfg, kubectl.CLI),
 		logger:              logger,
-		statusMonitor:       component.NewMonitor(cfg, cfg.GetKubeContext(), labeller, &namespaces, customResourceSelectors),
+		statusMonitor:       component.NewMonitor(cfg, configName, labeller, &namespaces, customResourceSelectors),
 		syncer:              component.NewSyncer(kubectl.CLI, &namespaces, logger.GetFormatter()),
 		manifestsNamespaces: &manifestsNamespaces,
 		hookRunner:          hooks.NewDeployRunner(kubectl.CLI, d.LifecycleHooks, &namespaces, logger.GetFormatter(), hooks.NewDeployEnvOpts(labeller.GetRunID(), kubectl.KubeContext, namespaces), &manifestsNamespaces),


### PR DESCRIPTION
Issue:
  - There's a Deployer created per config/module
  - Status Monitor was being deduped per kubecontext
  - Deployer and Status Monitor use a pointer to a list of namespaces to monitor
  - So basically we need a Status Monitor per Deployer
  - Dedup on the config name (those are unique right?)

<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #nnn <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
