### PR TITLE
fix status checks for multiple modules

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,119 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1709336216,
+        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gomod2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1710154385,
+        "narHash": "sha256-4c3zQ2YY4BZOufaBJB4v9VBBeN2dH7iVdoJw8SDNCfI=",
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "rev": "872b63ddd28f318489c929d25f1f0a3c6039c971",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1711523803,
+        "narHash": "sha256-UKcYiHWHQynzj6CN/vTcix4yd1eCu1uFdsuarupdCQQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2726f127c15a4cc9810843b96cad73c7eb39e443",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "gomod2nix": "gomod2nix",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,65 @@
+{
+  description = "Easy and Repeatable Kubernetes Development";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    flake-parts.url = "github:hercules-ci/flake-parts";
+
+    gomod2nix.url = "github:nix-community/gomod2nix";
+    gomod2nix.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+
+      perSystem = { pkgs, inputs', ... }: {
+
+        packages.default = let
+          buildDate = with inputs; "${self.lastModifiedDate or self.lastModified or "unknown"}";
+          version  = with inputs; "${self.shortRev or self.dirtyShortRev or buildDate}";
+        in inputs'.gomod2nix.legacyPackages.buildGoApplication {
+          pname = "skaffold";
+
+          inherit version;
+
+          src = inputs.self;
+
+          modules = null;
+
+          subPackages = ["cmd/skaffold"];
+
+          ldflags = let
+            p = "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold";
+          in [
+            "-s" "-w"
+            "-X ${p}/version.version=v${version}"
+            "-X ${p}/version.gitCommit=${inputs.self.rev or inputs.self.dirtyRev or "unkown"}"
+            "-X ${p}/version.buildDate=${buildDate}"
+          ];
+
+          nativeBuildInputs = with pkgs; [ installShellFiles makeWrapper ];
+
+          installCheckPhase = ''
+            $out/bin/skaffold version | grep ${version} > /dev/null
+          '';
+
+          postInstall = ''
+            wrapProgram $out/bin/skaffold --set SKAFFOLD_UPDATE_CHECK false
+
+            installShellCompletion --cmd skaffold \
+              --bash <($out/bin/skaffold completion bash) \
+              --zsh <($out/bin/skaffold completion zsh)
+          '';
+
+          meta = {
+            homepage = "https://github.com/GoogleContainerTools/skaffold";
+          };
+        };
+
+        packages.gomod2nix = inputs'.gomod2nix.packages.default;
+      };
+    };
+}

--- a/pkg/skaffold/deploy/component/kubernetes/component.go
+++ b/pkg/skaffold/deploy/component/kubernetes/component.go
@@ -93,7 +93,7 @@ func newLogger(config k8slogger.Config, cli *kubectl.CLI, podSelector kubernetes
 	return k8slogger.NewLogAggregator(cli, podSelector, namespaces, config)
 }
 
-func newMonitor(cfg k8sstatus.Config, kubeContext string, labeller *label.DefaultLabeller, namespaces *[]string, customResourceSelectors []manifest.GroupKindSelector) k8sstatus.Monitor {
+func newMonitor(cfg k8sstatus.Config, dedupKey string, labeller *label.DefaultLabeller, namespaces *[]string, customResourceSelectors []manifest.GroupKindSelector) k8sstatus.Monitor {
 	if customResourceSelectors == nil {
 		customResourceSelectors = []manifest.GroupKindSelector{}
 	}
@@ -102,15 +102,15 @@ func newMonitor(cfg k8sstatus.Config, kubeContext string, labeller *label.Defaul
 	if k8sMonitor == nil {
 		k8sMonitor = make(map[string]k8sstatus.Monitor)
 	}
-	if k8sMonitor[kubeContext] == nil {
+	if k8sMonitor[dedupKey] == nil {
 		enabled := cfg.StatusCheck()
 		if enabled != nil && !*enabled { // assume disabled only if explicitly set to false
-			k8sMonitor[kubeContext] = &k8sstatus.NoopMonitor{}
+			k8sMonitor[dedupKey] = &k8sstatus.NoopMonitor{}
 		} else {
-			k8sMonitor[kubeContext] = k8sstatus.NewStatusMonitor(cfg, labeller, namespaces, customResourceSelectors)
+			k8sMonitor[dedupKey] = k8sstatus.NewStatusMonitor(cfg, labeller, namespaces, customResourceSelectors)
 		}
 	}
-	return k8sMonitor[kubeContext]
+	return k8sMonitor[dedupKey]
 }
 
 func newSyncer(cli *kubectl.CLI, namespaces *[]string, formatter k8slogger.Formatter) sync.Syncer {

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -105,6 +105,7 @@ func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latest.KubectlD
 	podSelector := kubernetes.NewImageList()
 	kubectl := NewCLI(cfg, d.Flags, defaultNamespace)
 	namespaces, err := deployutil.GetAllPodNamespaces(cfg.GetNamespace(), cfg.GetPipelines())
+
 	if err != nil {
 		olog.Entry(context.TODO()).Warn("unable to parse namespaces - deploy might not work correctly!")
 	}
@@ -134,7 +135,7 @@ func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latest.KubectlD
 		debugger:            component.NewDebugger(cfg.Mode(), podSelector, &namespaces, cfg.GetKubeContext()),
 		imageLoader:         component.NewImageLoader(cfg, kubectl.CLI),
 		logger:              logger,
-		statusMonitor:       component.NewMonitor(cfg, cfg.GetKubeContext(), labeller, &namespaces, customResourceSelectors),
+		statusMonitor:       component.NewMonitor(cfg, configName, labeller, &namespaces, customResourceSelectors),
 		syncer:              component.NewSyncer(kubectl.CLI, &namespaces, logger.GetFormatter()),
 		manifestsNamespaces: &manifestsNamespaces,
 		hookRunner:          hooks.NewDeployRunner(kubectl.CLI, d.LifecycleHooks, &namespaces, logger.GetFormatter(), hooks.NewDeployEnvOpts(labeller.GetRunID(), kubectl.KubeContext, namespaces), &manifestsNamespaces),


### PR DESCRIPTION
Issue:

If you have workloads in different namespaces managed in different modules, Skaffold will only run status checks on the first module it encouters. This can be a problem when you have dependencies between the modules, where workloads in one must be healthy before moving onto the next (e.g. CRD operators).

For example,

```yaml
apiVersion: skaffold/v4beta8
kind: Config
metadata:
  name: a
manifests:
  kustomize:
    paths:
      - ./deploy-a.yaml
deploy:
  kubectl:
    flags:
      apply:
        -  --server-side
---
apiVersion: skaffold/v4beta8
kind: Config
metadata:
  name: b
manifests:
  kustomize:
    paths:
      - ./deploy-b.yaml
deploy:
  kubectl:
    flags:
      apply:
        -  --server-side
```

Where `deploy-a.yaml` looks something like:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: a
  namespace: a
spec:
  template:
    spec:
      containers:
        - name: default
          image: ...
          command: ["sleep", "inf"]
          livenessProbe:
            exec:
              command: ["true"]
            initialDelaySeconds: 15
            periodSeconds: 5
```

And `deploy-b.yaml` looks something like:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: b
  namespace: b
spec:
  template:
    spec:
      containers:
        - name: default
          image: ...
          command: ["sleep", "inf"]
          livenessProbe:
            exec:
              command: ["true"]
            initialDelaySeconds: 15
            periodSeconds: 5
```

Notes:
  - There's a Deployer created per config/module
  - Status Monitor was being deduped per kubecontext
  - Deployer and Status Monitor use a pointer to a list of namespaces to monitor
  - So basically we need a Status Monitor per Deployer
  - Dedup on the config name (those are unique right?)

Also added a Flake to this project, making it easy to install/run Skaffold with Nix:

```sh
nix run github:<org>/skaffold/<rev-or-ref
```
